### PR TITLE
Coordinate match seeds for synced multiplayer matches

### DIFF
--- a/game.js
+++ b/game.js
@@ -96,7 +96,11 @@
   fitCanvas();
 
   // --- Utils ---
-  const rand = (a, b) => a + Math.random() * (b - a);
+  let randomSource = Math.random;
+  const setRandomSource = (fn) => {
+    randomSource = typeof fn === 'function' ? fn : Math.random;
+  };
+  const rand = (a, b) => a + randomSource() * (b - a);
   const randi = (a, b) => Math.floor(rand(a, b));
   const clamp = (v, a, b) => Math.max(a, Math.min(b, v));
   const dist2 = (x1, y1, x2, y2) => {
@@ -106,6 +110,23 @@
   const mag = (x, y) => Math.hypot(x, y);
   const norm = (x, y) => { const m = Math.hypot(x, y) || 1; return [x / m, y / m]; };
   const ang = (x, y) => Math.atan2(y, x);
+
+  function makeSeededRng(seed) {
+    let h = 2166136261 >>> 0;
+    const text = String(seed || "");
+    for (let i = 0; i < text.length; i++) {
+      h ^= text.charCodeAt(i);
+      h = Math.imul(h, 16777619);
+    }
+    return () => {
+      h += h << 13;
+      h ^= h >>> 7;
+      h += h << 3;
+      h ^= h >>> 17;
+      h += h << 5;
+      return ((h >>> 0) & 0xffffffff) / 0xffffffff;
+    };
+  }
 
   function hash2(x, y) {
     const s = Math.sin(x * 12.9898 + y * 78.233) * 43758.5453;
@@ -808,27 +829,80 @@
   }
 
   // --- Game Flow ---
-  function startGame() {
-    world.time = 0;
-    world.phase = 0;
-    world.phaseTimer = CONFIG.zone.holdTime;
-    world.zone.r = CONFIG.zone.startRadius;
-    world.zone.rTarget = CONFIG.zone.startRadius;
-    world.zoneState = { mode: 'hold', timer: CONFIG.zone.holdTime, t: 0, T: 0, startR: world.zone.r, targetR: world.zone.r };
-    world.diff = DIFFICULTY[selectedDiff] || DIFFICULTY.insane;
-    world.mode = TEAM_MODES[selectedMode] || TEAM_MODES.solos;
-    generateWorld();
-    world.bullets = [];
-    world.bots = [];
-    clearRemotePlayers();
-    world.teams = [];
-    let colorIdx = 0; const nextColor = () => TEAM_COLORS[colorIdx++ % TEAM_COLORS.length];
-    const px = randi(200, CONFIG.mapW-200), py = randi(200, CONFIG.mapH-200);
-    world.player = makePlayer(px, py);
-    world.graceTimer = 1.0;
-    // Player team
-    const teamSize = world.mode.teamSize;
-    const playerTeam = makeTeam(0, nextColor());
+  function computePartySpawn(matchSeed, partyCtx, selfId) {
+    if (!matchSeed || !matchSeed.seed || !partyCtx || !partyCtx.code) return null;
+    const baseKey = `${partyCtx.code}:${matchSeed.seed}:${matchSeed.counter || 0}`;
+    const baseRng = makeSeededRng(baseKey);
+    const centerX = clamp(Math.round(200 + baseRng() * (CONFIG.mapW - 400)), 200, CONFIG.mapW - 200);
+    const centerY = clamp(Math.round(200 + baseRng() * (CONFIG.mapH - 400)), 200, CONFIG.mapH - 200);
+    if (!selfId) {
+      return { x: centerX, y: centerY };
+    }
+    const memberRng = makeSeededRng(`${baseKey}:${selfId}`);
+    const angle = memberRng() * Math.PI * 2;
+    const radius = 50 + memberRng() * 90;
+    const spawnX = clamp(centerX + Math.cos(angle) * radius, 120, CONFIG.mapW - 120);
+    const spawnY = clamp(centerY + Math.sin(angle) * radius, 120, CONFIG.mapH - 120);
+    return { x: spawnX, y: spawnY };
+  }
+
+  async function startGame() {
+    let spawnOverride = null;
+    let seededRng = null;
+    const mpBridge = (window.RiggedRoyale && window.RiggedRoyale.mp) || null;
+    if (mpBridge) {
+      try {
+        const ensureSeed = typeof mpBridge.ensureMatchSeed === 'function'
+          ? mpBridge.ensureMatchSeed({ fresh: true })
+          : null;
+        const info = ensureSeed ? await ensureSeed : null;
+        if (info) {
+          const partyCtx = typeof mpBridge.getPartyContext === 'function'
+            ? mpBridge.getPartyContext()
+            : null;
+          const selfId = typeof mpBridge.getSelfId === 'function'
+            ? mpBridge.getSelfId()
+            : null;
+          spawnOverride = computePartySpawn(info, partyCtx, selfId);
+          const seedKey = `${info.seed}:${info.counter || 0}:${partyCtx && partyCtx.code ? partyCtx.code : ''}`;
+          seededRng = makeSeededRng(seedKey);
+        }
+      } catch (err) {
+        console.warn('Failed to synchronize multiplayer match seed', err);
+      }
+    }
+
+    let seededApplied = false;
+    if (seededRng) {
+      setRandomSource(seededRng);
+      seededApplied = true;
+    } else {
+      setRandomSource(null);
+    }
+
+    try {
+      world.time = 0;
+      world.phase = 0;
+      world.phaseTimer = CONFIG.zone.holdTime;
+      world.zone.r = CONFIG.zone.startRadius;
+      world.zone.rTarget = CONFIG.zone.startRadius;
+      world.zoneState = { mode: 'hold', timer: CONFIG.zone.holdTime, t: 0, T: 0, startR: world.zone.r, targetR: world.zone.r };
+      world.diff = DIFFICULTY[selectedDiff] || DIFFICULTY.insane;
+      world.mode = TEAM_MODES[selectedMode] || TEAM_MODES.solos;
+      generateWorld();
+      world.bullets = [];
+      world.bots = [];
+      clearRemotePlayers();
+      world.teams = [];
+      let colorIdx = 0; const nextColor = () => TEAM_COLORS[colorIdx++ % TEAM_COLORS.length];
+      const spawn = spawnOverride || { x: randi(200, CONFIG.mapW-200), y: randi(200, CONFIG.mapH-200) };
+      const px = clamp(spawn.x, 120, CONFIG.mapW - 120);
+      const py = clamp(spawn.y, 120, CONFIG.mapH - 120);
+      world.player = makePlayer(px, py);
+      world.graceTimer = 1.0;
+      // Player team
+      const teamSize = world.mode.teamSize;
+      const playerTeam = makeTeam(0, nextColor());
     world.teams.push(playerTeam);
     assignTeam(world.player, playerTeam);
     // Teammates
@@ -856,6 +930,11 @@
     }
     hideOverlay();
     world.running = true; world.paused = false;
+    } finally {
+      if (seededApplied) {
+        setRandomSource(null);
+      }
+    }
   }
 
   // --- Weapons & Inventory helpers ---
@@ -944,13 +1023,17 @@
       bodyEl.classList.remove('playing');
     } catch(_) {}
   }
-  playBtn.addEventListener('click', () => {
+  playBtn.addEventListener('click', async () => {
     hideOverlay();
-    if (!world.running || !world.player) startGame(); else { world.paused = false; }
+    if (!world.running || !world.player) {
+      await startGame();
+    } else {
+      world.paused = false;
+    }
     // double-check in next frame
     requestAnimationFrame(() => hideOverlay());
   });
-  restartBtn.addEventListener('click', () => { startGame(); saveDiff(); saveMode(); });
+  restartBtn.addEventListener('click', async () => { await startGame(); saveDiff(); saveMode(); });
   spectateBtn.addEventListener('click', () => {
     if (!world.player) return;
     world.spectating = true;

--- a/server.js
+++ b/server.js
@@ -3,6 +3,7 @@
 // Core imports
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { randomUUID } from "node:crypto";
 import express from "express";
 import { createServer } from "node:http";
 import { Server } from "socket.io";
@@ -41,6 +42,66 @@ const sanitizeName = (raw) => {
   if (typeof raw !== "string") return "";
   const trimmed = raw.replace(/\s+/g, " ").replace(/[^\x20-\x7E]/g, "").trim();
   return trimmed.slice(0, NAME_MAX_LENGTH);
+};
+
+const clampNumber = (value, min, max, fallback = 0) => {
+  const num = Number(value);
+  if (!Number.isFinite(num)) return fallback;
+  let result = num;
+  if (typeof min === "number") result = Math.max(min, result);
+  if (typeof max === "number") result = Math.min(max, result);
+  return result;
+};
+
+const sanitizePlayerState = (raw) => {
+  if (!raw || typeof raw !== "object") return null;
+  const state = {};
+  if (Number.isFinite(Number(raw.x))) state.x = clampNumber(raw.x, -5000, 5000, Number(raw.x));
+  if (Number.isFinite(Number(raw.y))) state.y = clampNumber(raw.y, -5000, 5000, Number(raw.y));
+  if (Number.isFinite(Number(raw.vx))) state.vx = clampNumber(raw.vx, -4000, 4000, Number(raw.vx));
+  if (Number.isFinite(Number(raw.vy))) state.vy = clampNumber(raw.vy, -4000, 4000, Number(raw.vy));
+  if (Number.isFinite(Number(raw.hp))) state.hp = clampNumber(raw.hp, -10, 250, Number(raw.hp));
+  if (Number.isFinite(Number(raw.stamina)))
+    state.stamina = clampNumber(raw.stamina, 0, 120, Number(raw.stamina));
+  if (raw.alive !== undefined) state.alive = Boolean(raw.alive);
+  if (raw.downed !== undefined) state.downed = Boolean(raw.downed);
+  if (raw.spectator !== undefined) state.spectator = Boolean(raw.spectator);
+  if (typeof raw.teamId === "number" && Number.isFinite(raw.teamId))
+    state.teamId = Math.round(raw.teamId);
+  if (typeof raw.teamColor === "string") state.teamColor = raw.teamColor.slice(0, 32);
+  if (typeof raw.weapon === "string") state.weapon = raw.weapon.slice(0, 24);
+  if (typeof raw.mode === "string") state.mode = raw.mode.slice(0, 16);
+  if (typeof raw.diff === "string") state.diff = raw.diff.slice(0, 16);
+  if (Number.isFinite(Number(raw.latency))) {
+    state.latency = clampNumber(raw.latency, 0, 10000, Number(raw.latency));
+  }
+  return Object.keys(state).length ? state : null;
+};
+
+const STATE_TTL_MS = 15_000;
+
+const getActiveStates = (party) => {
+  if (!party || !party.states) return [];
+  const now = Date.now();
+  const result = [];
+  for (const [id, snapshot] of party.states.entries()) {
+    if (!snapshot) {
+      party.states.delete(id);
+      continue;
+    }
+    if (now - (snapshot.updatedAt || 0) > STATE_TTL_MS) {
+      party.states.delete(id);
+      continue;
+    }
+    result.push(snapshot);
+  }
+  return result;
+};
+
+const sendPartyStates = (party, socket) => {
+  if (!party || !socket) return;
+  const payload = getActiveStates(party).filter((entry) => entry.id !== socket.id);
+  if (payload.length) socket.emit("state:bulk", payload);
 };
 
 const ensureDisplayName = (socket, maybeName) => {
@@ -104,6 +165,10 @@ const leaveParty = (socket, opts = {}) => {
     return;
   }
   party.members.delete(socket.id);
+  if (party.states) {
+    party.states.delete(socket.id);
+  }
+  socket.to(roomName(existingCode)).emit("state:remove", { id: socket.id });
   if (party.hostId === socket.id) {
     const nextMember = party.members.values().next().value;
     if (nextMember) {
@@ -122,6 +187,7 @@ const leaveParty = (socket, opts = {}) => {
 
 const joinParty = (party, socket, name) => {
   if (!party) return;
+  if (!party.states) party.states = new Map();
   if (party.members.size >= MAX_PARTY_SIZE) {
     socket.emit("party:error", { message: "Party is full." });
     return;
@@ -137,6 +203,7 @@ const joinParty = (party, socket, name) => {
   socket.data.partyCode = party.code;
   socket.join(roomName(party.code));
   socket.emit("party:joined", { code: party.code });
+  sendPartyStates(party, socket);
   broadcastParty(party);
 };
 
@@ -198,7 +265,9 @@ io.on("connection", (socket) => {
       code,
       hostId: socket.id,
       members: new Map(),
-      createdAt: Date.now()
+      states: new Map(),
+      createdAt: Date.now(),
+      match: { counter: 0, latest: null }
     };
     parties.set(code, party);
     joinParty(party, socket);
@@ -222,6 +291,9 @@ io.on("connection", (socket) => {
     ensureDisplayName(socket, name);
     leaveParty(socket, { notifySelf: false });
     joinParty(party, socket);
+    if (party.match && party.match.latest) {
+      socket.emit("match:seed", party.match.latest);
+    }
   });
 
   socket.on("party:leave", () => {
@@ -239,7 +311,58 @@ io.on("connection", (socket) => {
       return;
     }
     socket.join(roomName(party.code));
+    sendPartyStates(party, socket);
     broadcastParty(party);
+    if (party.match && party.match.latest) {
+      socket.emit("match:seed", party.match.latest);
+    }
+  });
+
+  socket.on("state:update", (payload = {}) => {
+    const party = getPartyForSocket(socket);
+    if (!party) return;
+    if (!party.states) party.states = new Map();
+    const sanitized = sanitizePlayerState(payload);
+    if (!sanitized) return;
+    sanitized.id = socket.id;
+    sanitized.name = socket.data.displayName;
+    sanitized.updatedAt = Date.now();
+    party.states.set(socket.id, sanitized);
+    socket.to(roomName(party.code)).emit("state:delta", sanitized);
+  });
+
+  socket.on("state:request", () => {
+    const party = getPartyForSocket(socket);
+    if (!party) {
+      socket.emit("state:bulk", []);
+      return;
+    }
+    sendPartyStates(party, socket);
+  });
+
+  socket.on("match:request", ({ requestId } = {}) => {
+    const party = getPartyForSocket(socket);
+    if (!party) return;
+    if (!party.match) party.match = { counter: 0, latest: null };
+    const now = Date.now();
+    party.match.counter = (party.match.counter || 0) + 1;
+    const payload = {
+      seed: randomUUID(),
+      counter: party.match.counter,
+      issuedAt: now,
+      by: socket.id
+    };
+    party.match.latest = payload;
+    io.to(roomName(party.code)).emit("match:seed", payload);
+    if (requestId) {
+      socket.emit("match:seed:ack", { requestId, ...payload });
+    }
+  });
+
+  socket.on("match:get", () => {
+    const party = getPartyForSocket(socket);
+    if (!party || !party.match || !party.match.latest) return;
+    socket.emit("match:seed", party.match.latest);
   });
 
   socket.on("disconnect", () => {


### PR DESCRIPTION
## Summary
- generate and broadcast per-party match seeds on the server so members join matches with the same shared data
- expose party context and match seed helpers to the multiplayer UI and game so clients request the seed and sync spawns with deterministic RNG

## Testing
- node --check server.js
- node --check multiplayer.js

------
https://chatgpt.com/codex/tasks/task_e_68d83da7df588328964f2576823f4f2a