### PR TITLE
Auto-launch party matches for non-host players

### DIFF
--- a/game.js
+++ b/game.js
@@ -66,6 +66,9 @@
   let selectedDiff = 'insane';
   let selectedMode = 'solos';
   let joystickEnabled = false;
+  let activeMatchCounter = null;
+  let matchReadyUnsub = null;
+  let startGamePromise = null;
   diffBtns.forEach(btn => btn.addEventListener('click', () => {
     selectedDiff = btn.dataset.diff;
     diffBtns.forEach(b => b.classList.toggle('selected', b === btn));
@@ -80,6 +83,52 @@
       saveJoystick();
     });
   }
+
+  const toMatchCounter = (value) => {
+    const num = Number(value);
+    return Number.isFinite(num) ? num : null;
+  };
+
+  const getMpBridge = () =>
+    (window.RiggedRoyale && window.RiggedRoyale.mp) || null;
+
+  function ensureAutoMatchSubscription() {
+    if (matchReadyUnsub) return;
+    const mpBridge = getMpBridge();
+    if (!mpBridge || typeof mpBridge.onMatchReady !== 'function') return;
+    matchReadyUnsub = mpBridge.onMatchReady((info) => {
+      if (!info) return;
+      const partyCtx =
+        typeof mpBridge.getPartyContext === 'function'
+          ? mpBridge.getPartyContext()
+          : null;
+      const selfId =
+        typeof mpBridge.getSelfId === 'function'
+          ? mpBridge.getSelfId()
+          : null;
+      const inParty = partyCtx && partyCtx.code;
+      const isHost = inParty && partyCtx && partyCtx.hostId === selfId;
+      if (!inParty || isHost) return;
+      const incomingCounter = toMatchCounter(info.counter);
+      if (
+        incomingCounter !== null &&
+        activeMatchCounter !== null &&
+        incomingCounter === activeMatchCounter
+      ) {
+        return;
+      }
+      if (startGamePromise) return;
+      startGame().catch((err) => {
+        console.warn('Failed to auto-start multiplayer match', err);
+        showOverlay();
+      });
+    });
+  }
+
+  if (typeof window.addEventListener === 'function') {
+    window.addEventListener('rr:mp:ready', ensureAutoMatchSubscription);
+  }
+  ensureAutoMatchSubscription();
 
   // Resize canvas to fill screen
   function fitCanvas() {
@@ -96,7 +145,11 @@
   fitCanvas();
 
   // --- Utils ---
-  const rand = (a, b) => a + Math.random() * (b - a);
+  let randomSource = Math.random;
+  const setRandomSource = (fn) => {
+    randomSource = typeof fn === 'function' ? fn : Math.random;
+  };
+  const rand = (a, b) => a + randomSource() * (b - a);
   const randi = (a, b) => Math.floor(rand(a, b));
   const clamp = (v, a, b) => Math.max(a, Math.min(b, v));
   const dist2 = (x1, y1, x2, y2) => {
@@ -106,6 +159,23 @@
   const mag = (x, y) => Math.hypot(x, y);
   const norm = (x, y) => { const m = Math.hypot(x, y) || 1; return [x / m, y / m]; };
   const ang = (x, y) => Math.atan2(y, x);
+
+  function makeSeededRng(seed) {
+    let h = 2166136261 >>> 0;
+    const text = String(seed || "");
+    for (let i = 0; i < text.length; i++) {
+      h ^= text.charCodeAt(i);
+      h = Math.imul(h, 16777619);
+    }
+    return () => {
+      h += h << 13;
+      h ^= h >>> 7;
+      h += h << 3;
+      h ^= h >>> 17;
+      h += h << 5;
+      return ((h >>> 0) & 0xffffffff) / 0xffffffff;
+    };
+  }
 
   function hash2(x, y) {
     const s = Math.sin(x * 12.9898 + y * 78.233) * 43758.5453;
@@ -808,54 +878,161 @@
   }
 
   // --- Game Flow ---
-  function startGame() {
-    world.time = 0;
-    world.phase = 0;
-    world.phaseTimer = CONFIG.zone.holdTime;
-    world.zone.r = CONFIG.zone.startRadius;
-    world.zone.rTarget = CONFIG.zone.startRadius;
-    world.zoneState = { mode: 'hold', timer: CONFIG.zone.holdTime, t: 0, T: 0, startR: world.zone.r, targetR: world.zone.r };
-    world.diff = DIFFICULTY[selectedDiff] || DIFFICULTY.insane;
-    world.mode = TEAM_MODES[selectedMode] || TEAM_MODES.solos;
-    generateWorld();
-    world.bullets = [];
-    world.bots = [];
-    clearRemotePlayers();
-    world.teams = [];
-    let colorIdx = 0; const nextColor = () => TEAM_COLORS[colorIdx++ % TEAM_COLORS.length];
-    const px = randi(200, CONFIG.mapW-200), py = randi(200, CONFIG.mapH-200);
-    world.player = makePlayer(px, py);
-    world.graceTimer = 1.0;
-    // Player team
-    const teamSize = world.mode.teamSize;
-    const playerTeam = makeTeam(0, nextColor());
-    world.teams.push(playerTeam);
-    assignTeam(world.player, playerTeam);
-    // Teammates
-    let remainingBots = Math.max(0, world.diff.bots);
-    for (let i=0; i<teamSize-1; i++) {
-      const mate = makeBot(px + randi(-120,120), py + randi(-120,120), i);
-      assignTeam(mate, playerTeam);
-      world.bots.push(mate);
+  function computePartySpawn(matchSeed, partyCtx, selfId) {
+    if (!matchSeed || !matchSeed.seed || !partyCtx || !partyCtx.code) return null;
+    const baseKey = `${partyCtx.code}:${matchSeed.seed}:${matchSeed.counter || 0}`;
+    const baseRng = makeSeededRng(baseKey);
+    const centerX = clamp(Math.round(200 + baseRng() * (CONFIG.mapW - 400)), 200, CONFIG.mapW - 200);
+    const centerY = clamp(Math.round(200 + baseRng() * (CONFIG.mapH - 400)), 200, CONFIG.mapH - 200);
+    if (!selfId) {
+      return { x: centerX, y: centerY };
     }
-    remainingBots -= Math.max(0, teamSize-1);
-    // Enemy teams
-    let teamId = 1;
-    while (remainingBots > 0) {
-      const t = makeTeam(teamId++, nextColor());
-      world.teams.push(t);
-      const spawnCount = Math.min(world.mode.teamSize, remainingBots);
-      let x, y;
-      do { x = randi(100, CONFIG.mapW-100); y = randi(100, CONFIG.mapH-100); } while (dist2(x,y,px,py) < 600*600);
-      for (let k=0; k<spawnCount; k++) {
-        const b = makeBot(x + randi(-140,140), y + randi(-140,140), world.bots.length);
-        assignTeam(b, t);
-        world.bots.push(b);
+    const memberRng = makeSeededRng(`${baseKey}:${selfId}`);
+    const angle = memberRng() * Math.PI * 2;
+    const radius = 50 + memberRng() * 90;
+    const spawnX = clamp(centerX + Math.cos(angle) * radius, 120, CONFIG.mapW - 120);
+    const spawnY = clamp(centerY + Math.sin(angle) * radius, 120, CONFIG.mapH - 120);
+    return { x: spawnX, y: spawnY };
+  }
+
+  async function startGame() {
+    if (startGamePromise) {
+      return startGamePromise;
+    }
+    startGamePromise = (async () => {
+      let spawnOverride = null;
+      let seededRng = null;
+      let started = false;
+      const mpBridge = getMpBridge();
+      let partyCtx = null;
+      let selfId = null;
+      if (mpBridge) {
+        if (typeof mpBridge.getPartyContext === 'function') {
+          partyCtx = mpBridge.getPartyContext();
+        }
+        if (typeof mpBridge.getSelfId === 'function') {
+          selfId = mpBridge.getSelfId();
+        }
       }
-      remainingBots -= spawnCount;
+      const inParty = partyCtx && partyCtx.code;
+      const isHost = inParty && partyCtx && partyCtx.hostId === selfId;
+      if (!inParty) {
+        activeMatchCounter = null;
+      }
+      if (mpBridge) {
+        ensureAutoMatchSubscription();
+        try {
+          const ensureSeed =
+            typeof mpBridge.ensureMatchSeed === 'function'
+              ? mpBridge.ensureMatchSeed({ fresh: true })
+              : null;
+          const info = ensureSeed ? await ensureSeed : null;
+          if (!info) {
+            if (inParty && !isHost) {
+              if (typeof mpBridge.notifyAwaitingHost === 'function') {
+                mpBridge.notifyAwaitingHost();
+              }
+              subtitle.textContent = 'Waiting for host to start the match';
+              showOverlay();
+              return false;
+            }
+            activeMatchCounter = null;
+          } else {
+            const counter = toMatchCounter(info.counter);
+            activeMatchCounter = counter;
+            spawnOverride = computePartySpawn(info, partyCtx, selfId);
+            const seedKey = `${info.seed}:${info.counter || 0}:${
+              partyCtx && partyCtx.code ? partyCtx.code : ''
+            }`;
+            seededRng = makeSeededRng(seedKey);
+            if (typeof mpBridge.markSeedActive === 'function') {
+              mpBridge.markSeedActive(info.counter);
+            }
+          }
+        } catch (err) {
+          console.warn('Failed to synchronize multiplayer match seed', err);
+        }
+      } else {
+        activeMatchCounter = null;
+      }
+
+      let seededApplied = false;
+      if (seededRng) {
+        setRandomSource(seededRng);
+        seededApplied = true;
+      } else {
+        setRandomSource(null);
+      }
+
+      try {
+        world.time = 0;
+        world.phase = 0;
+        world.phaseTimer = CONFIG.zone.holdTime;
+        world.zone.r = CONFIG.zone.startRadius;
+        world.zone.rTarget = CONFIG.zone.startRadius;
+        world.zoneState = { mode: 'hold', timer: CONFIG.zone.holdTime, t: 0, T: 0, startR: world.zone.r, targetR: world.zone.r };
+        world.diff = DIFFICULTY[selectedDiff] || DIFFICULTY.insane;
+        world.mode = TEAM_MODES[selectedMode] || TEAM_MODES.solos;
+        generateWorld();
+        world.bullets = [];
+        world.bots = [];
+        clearRemotePlayers();
+        world.teams = [];
+        let colorIdx = 0;
+        const nextColor = () => TEAM_COLORS[colorIdx++ % TEAM_COLORS.length];
+        const spawn =
+          spawnOverride || { x: randi(200, CONFIG.mapW - 200), y: randi(200, CONFIG.mapH - 200) };
+        const px = clamp(spawn.x, 120, CONFIG.mapW - 120);
+        const py = clamp(spawn.y, 120, CONFIG.mapH - 120);
+        world.player = makePlayer(px, py);
+        world.graceTimer = 1.0;
+        // Player team
+        const teamSize = world.mode.teamSize;
+        const playerTeam = makeTeam(0, nextColor());
+        world.teams.push(playerTeam);
+        assignTeam(world.player, playerTeam);
+        // Teammates
+        let remainingBots = Math.max(0, world.diff.bots);
+        for (let i = 0; i < teamSize - 1; i++) {
+          const mate = makeBot(px + randi(-120, 120), py + randi(-120, 120), i);
+          assignTeam(mate, playerTeam);
+          world.bots.push(mate);
+        }
+        remainingBots -= Math.max(0, teamSize - 1);
+        // Enemy teams
+        let teamId = 1;
+        while (remainingBots > 0) {
+          const t = makeTeam(teamId++, nextColor());
+          world.teams.push(t);
+          const spawnCount = Math.min(world.mode.teamSize, remainingBots);
+          let x, y;
+          do {
+            x = randi(100, CONFIG.mapW - 100);
+            y = randi(100, CONFIG.mapH - 100);
+          } while (dist2(x, y, px, py) < 600 * 600);
+          for (let k = 0; k < spawnCount; k++) {
+            const b = makeBot(x + randi(-140, 140), y + randi(-140, 140), world.bots.length);
+            assignTeam(b, t);
+            world.bots.push(b);
+          }
+          remainingBots -= spawnCount;
+        }
+        hideOverlay();
+        world.running = true;
+        world.paused = false;
+        started = true;
+      } finally {
+        if (seededApplied) {
+          setRandomSource(null);
+        }
+      }
+      return started;
+    })();
+    try {
+      return await startGamePromise;
+    } finally {
+      startGamePromise = null;
     }
-    hideOverlay();
-    world.running = true; world.paused = false;
   }
 
   // --- Weapons & Inventory helpers ---
@@ -944,13 +1121,26 @@
       bodyEl.classList.remove('playing');
     } catch(_) {}
   }
-  playBtn.addEventListener('click', () => {
+  playBtn.addEventListener('click', async () => {
     hideOverlay();
-    if (!world.running || !world.player) startGame(); else { world.paused = false; }
-    // double-check in next frame
-    requestAnimationFrame(() => hideOverlay());
+    let started = true;
+    if (!world.running || !world.player) {
+      started = await startGame();
+    } else {
+      world.paused = false;
+    }
+    if (started) {
+      // double-check in next frame
+      requestAnimationFrame(() => hideOverlay());
+    }
   });
-  restartBtn.addEventListener('click', () => { startGame(); saveDiff(); saveMode(); });
+  restartBtn.addEventListener('click', async () => {
+    const started = await startGame();
+    if (started) {
+      saveDiff();
+      saveMode();
+    }
+  });
   spectateBtn.addEventListener('click', () => {
     if (!world.player) return;
     world.spectating = true;

--- a/game.js
+++ b/game.js
@@ -167,13 +167,14 @@
       h ^= text.charCodeAt(i);
       h = Math.imul(h, 16777619);
     }
+    const normalize = 1 / 0x100000000; // 2^32
     return () => {
       h += h << 13;
       h ^= h >>> 7;
       h += h << 3;
       h ^= h >>> 17;
       h += h << 5;
-      return ((h >>> 0) & 0xffffffff) / 0xffffffff;
+      return (h >>> 0) * normalize;
     };
   }
 

--- a/index.html
+++ b/index.html
@@ -11,15 +11,16 @@
     <div id="hud">
       <div id="status"></div>
       <div id="instructions">
-        WASD to move
+        WASD to move &bull; Shift to sprint &bull; Mouse to aim &bull; Click to shoot &bull;
+        1/2/3 or Scroll to swap &bull; R to reload &bull; E to revive &bull; M to mute &bull;
+        Pickups auto &bull; P to pause
+      </div>
+    </div>
     <div id="joystick">
       <div id="joystickArea">
         <div id="joystickBase">
           <div id="joystickThumb"></div>
         </div>
-      </div>
-    </div>
- â€¢ Shift to sprint â€¢ Mouse to aim â€¢ Click to shoot â€¢ 1/2/3 or Scroll to swap â€¢ R to reload â€¢ E to revive â€¢ M to mute â€¢ Pickups auto â€¢ P to pause
       </div>
     </div>
     <div id="overlay">

--- a/server.js
+++ b/server.js
@@ -3,6 +3,7 @@
 // Core imports
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { randomUUID } from "node:crypto";
 import express from "express";
 import { createServer } from "node:http";
 import { Server } from "socket.io";
@@ -41,6 +42,66 @@ const sanitizeName = (raw) => {
   if (typeof raw !== "string") return "";
   const trimmed = raw.replace(/\s+/g, " ").replace(/[^\x20-\x7E]/g, "").trim();
   return trimmed.slice(0, NAME_MAX_LENGTH);
+};
+
+const clampNumber = (value, min, max, fallback = 0) => {
+  const num = Number(value);
+  if (!Number.isFinite(num)) return fallback;
+  let result = num;
+  if (typeof min === "number") result = Math.max(min, result);
+  if (typeof max === "number") result = Math.min(max, result);
+  return result;
+};
+
+const sanitizePlayerState = (raw) => {
+  if (!raw || typeof raw !== "object") return null;
+  const state = {};
+  if (Number.isFinite(Number(raw.x))) state.x = clampNumber(raw.x, -5000, 5000, Number(raw.x));
+  if (Number.isFinite(Number(raw.y))) state.y = clampNumber(raw.y, -5000, 5000, Number(raw.y));
+  if (Number.isFinite(Number(raw.vx))) state.vx = clampNumber(raw.vx, -4000, 4000, Number(raw.vx));
+  if (Number.isFinite(Number(raw.vy))) state.vy = clampNumber(raw.vy, -4000, 4000, Number(raw.vy));
+  if (Number.isFinite(Number(raw.hp))) state.hp = clampNumber(raw.hp, -10, 250, Number(raw.hp));
+  if (Number.isFinite(Number(raw.stamina)))
+    state.stamina = clampNumber(raw.stamina, 0, 120, Number(raw.stamina));
+  if (raw.alive !== undefined) state.alive = Boolean(raw.alive);
+  if (raw.downed !== undefined) state.downed = Boolean(raw.downed);
+  if (raw.spectator !== undefined) state.spectator = Boolean(raw.spectator);
+  if (typeof raw.teamId === "number" && Number.isFinite(raw.teamId))
+    state.teamId = Math.round(raw.teamId);
+  if (typeof raw.teamColor === "string") state.teamColor = raw.teamColor.slice(0, 32);
+  if (typeof raw.weapon === "string") state.weapon = raw.weapon.slice(0, 24);
+  if (typeof raw.mode === "string") state.mode = raw.mode.slice(0, 16);
+  if (typeof raw.diff === "string") state.diff = raw.diff.slice(0, 16);
+  if (Number.isFinite(Number(raw.latency))) {
+    state.latency = clampNumber(raw.latency, 0, 10000, Number(raw.latency));
+  }
+  return Object.keys(state).length ? state : null;
+};
+
+const STATE_TTL_MS = 15_000;
+
+const getActiveStates = (party) => {
+  if (!party || !party.states) return [];
+  const now = Date.now();
+  const result = [];
+  for (const [id, snapshot] of party.states.entries()) {
+    if (!snapshot) {
+      party.states.delete(id);
+      continue;
+    }
+    if (now - (snapshot.updatedAt || 0) > STATE_TTL_MS) {
+      party.states.delete(id);
+      continue;
+    }
+    result.push(snapshot);
+  }
+  return result;
+};
+
+const sendPartyStates = (party, socket) => {
+  if (!party || !socket) return;
+  const payload = getActiveStates(party).filter((entry) => entry.id !== socket.id);
+  if (payload.length) socket.emit("state:bulk", payload);
 };
 
 const ensureDisplayName = (socket, maybeName) => {
@@ -104,6 +165,13 @@ const leaveParty = (socket, opts = {}) => {
     return;
   }
   party.members.delete(socket.id);
+  if (party.match && party.match.pending) {
+    party.match.pending.delete(socket.id);
+  }
+  if (party.states) {
+    party.states.delete(socket.id);
+  }
+  socket.to(roomName(existingCode)).emit("state:remove", { id: socket.id });
   if (party.hostId === socket.id) {
     const nextMember = party.members.values().next().value;
     if (nextMember) {
@@ -122,6 +190,7 @@ const leaveParty = (socket, opts = {}) => {
 
 const joinParty = (party, socket, name) => {
   if (!party) return;
+  if (!party.states) party.states = new Map();
   if (party.members.size >= MAX_PARTY_SIZE) {
     socket.emit("party:error", { message: "Party is full." });
     return;
@@ -137,6 +206,7 @@ const joinParty = (party, socket, name) => {
   socket.data.partyCode = party.code;
   socket.join(roomName(party.code));
   socket.emit("party:joined", { code: party.code });
+  sendPartyStates(party, socket);
   broadcastParty(party);
 };
 
@@ -198,7 +268,9 @@ io.on("connection", (socket) => {
       code,
       hostId: socket.id,
       members: new Map(),
-      createdAt: Date.now()
+      states: new Map(),
+      createdAt: Date.now(),
+      match: { counter: 0, latest: null, pending: new Map() }
     };
     parties.set(code, party);
     joinParty(party, socket);
@@ -222,6 +294,9 @@ io.on("connection", (socket) => {
     ensureDisplayName(socket, name);
     leaveParty(socket, { notifySelf: false });
     joinParty(party, socket);
+    if (party.match && party.match.latest) {
+      socket.emit("match:seed", party.match.latest);
+    }
   });
 
   socket.on("party:leave", () => {
@@ -239,7 +314,129 @@ io.on("connection", (socket) => {
       return;
     }
     socket.join(roomName(party.code));
+    sendPartyStates(party, socket);
     broadcastParty(party);
+    if (party.match && party.match.latest) {
+      socket.emit("match:seed", party.match.latest);
+    }
+  });
+
+  socket.on("state:update", (payload = {}) => {
+    const party = getPartyForSocket(socket);
+    if (!party) return;
+    if (!party.states) party.states = new Map();
+    const sanitized = sanitizePlayerState(payload);
+    if (!sanitized) return;
+    sanitized.id = socket.id;
+    sanitized.name = socket.data.displayName;
+    sanitized.updatedAt = Date.now();
+    party.states.set(socket.id, sanitized);
+    socket.to(roomName(party.code)).emit("state:delta", sanitized);
+  });
+
+  socket.on("state:request", () => {
+    const party = getPartyForSocket(socket);
+    if (!party) {
+      socket.emit("state:bulk", []);
+      return;
+    }
+    sendPartyStates(party, socket);
+  });
+
+  socket.on("match:request", ({ requestId, afterCounter } = {}) => {
+    const party = getPartyForSocket(socket);
+    if (!party) return;
+    if (!party.match) {
+      party.match = { counter: 0, latest: null, pending: new Map() };
+    }
+    if (!party.match.pending) {
+      party.match.pending = new Map();
+    }
+    const now = Date.now();
+    const requestedMinCounter = Number.isFinite(Number(afterCounter))
+      ? Number(afterCounter)
+      : null;
+    const pending = party.match.pending;
+
+    const sendSeedToSocket = (targetId, payload) => {
+      if (!targetId) return;
+      io.to(targetId).emit("match:seed", payload);
+    };
+    const ackSeedToSocket = (targetId, payload, waiterRequestId) => {
+      if (!targetId || !waiterRequestId) return;
+      io.to(targetId).emit("match:seed:ack", { requestId: waiterRequestId, ...payload });
+    };
+
+    const isHost = party.hostId === socket.id;
+    if (!isHost) {
+      const latest = party.match.latest || null;
+      const latestCounter = latest && Number.isFinite(Number(latest.counter))
+        ? Number(latest.counter)
+        : null;
+      if (
+        requestedMinCounter !== null &&
+        (latestCounter === null || latestCounter < requestedMinCounter)
+      ) {
+        pending.set(socket.id, {
+          socketId: socket.id,
+          requestId,
+          requestedAt: now,
+          minCounter: requestedMinCounter
+        });
+      } else if (latest) {
+        sendSeedToSocket(socket.id, latest);
+        if (requestId) {
+          socket.emit("match:seed:ack", { requestId, ...latest });
+        }
+      } else {
+        pending.set(socket.id, {
+          socketId: socket.id,
+          requestId,
+          requestedAt: now,
+          minCounter: requestedMinCounter
+        });
+      }
+      return;
+    }
+
+    pending.delete(socket.id);
+    party.match.counter = (party.match.counter || 0) + 1;
+    const payload = {
+      seed: randomUUID(),
+      counter: party.match.counter,
+      issuedAt: now,
+      by: socket.id
+    };
+    party.match.latest = payload;
+    io.to(roomName(party.code)).emit("match:seed", payload);
+    if (requestId) {
+      socket.emit("match:seed:ack", { requestId, ...payload });
+    }
+    if (pending.size) {
+      for (const [id, waiter] of pending.entries()) {
+        const target = io.sockets.sockets.get(id);
+        if (!target || target.data.partyCode !== party.code) {
+          pending.delete(id);
+          continue;
+        }
+        if (
+          waiter.minCounter !== null &&
+          Number.isFinite(Number(waiter.minCounter)) &&
+          Number(waiter.minCounter) > payload.counter
+        ) {
+          continue;
+        }
+        sendSeedToSocket(id, payload);
+        ackSeedToSocket(id, payload, waiter.requestId);
+        pending.delete(id);
+      }
+    }
+  });
+
+  socket.on("match:get", () => {
+    const party = getPartyForSocket(socket);
+    if (!party || !party.match || !party.match.latest) return;
+    socket.emit("match:seed", party.match.latest);
   });
 
   socket.on("disconnect", () => {


### PR DESCRIPTION
## Summary
- add a multiplayer bridge event so the game can subscribe when a fresh party match seed arrives and emit a browser event when the client is ready
- update the game flow to guard concurrent start attempts, auto-subscribe to match-ready notifications, and restart non-host clients as soon as the host seeds a round

## Testing
- node --check server.js
- node --check multiplayer.js
- node --check game.js

------
https://chatgpt.com/codex/tasks/task_e_68d83da7df588328964f2576823f4f2a